### PR TITLE
Change of activity opening

### DIFF
--- a/app/src/main/java/com/example/mario/raizin/SkinTypeDeterminationActivityContinuation.java
+++ b/app/src/main/java/com/example/mario/raizin/SkinTypeDeterminationActivityContinuation.java
@@ -85,7 +85,7 @@ public class SkinTypeDeterminationActivityContinuation extends AppCompatActivity
                     inSkinType.putExtra("skinTypeChosen", "Oily Skin");
                     startActivity(inSkinType);
 
-                    Intent inTimer=new Intent(getApplicationContext(), TimeOutsideActivity.class);
+                    Intent inTimer=new Intent(getApplicationContext(), HomeFeed.class);
                     inTimer.putExtra("spfFactor", spfFactor);
                     inTimer.putExtra("estimatedTime", estimatedTime);    //was estimatedTime
                     inTimer.putExtra("skinTypeChosen", "Oily Skin");


### PR DESCRIPTION
When oily skin was selected and the next button was pressed, it would open up the time outside activity as opposed to the Home feed activity as it should.