### PR TITLE
HomeFeed navigation fix

### DIFF
--- a/app/src/main/java/com/example/mario/raizin/HomeFeed.java
+++ b/app/src/main/java/com/example/mario/raizin/HomeFeed.java
@@ -23,6 +23,10 @@ public class HomeFeed extends AppCompatActivity {
     TextView recommendedIntervalOfApplicationObject;
     TextView skinTypeDisplayObject;
 
+    public void onBackPressed() {
+        //super.onBackPressed();
+        // dont call **super**, if u want disable back button in current screen.
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
The HomeFeed navigation issue #10 is fixed, meaning that no backwards navigation from the HomeFeed is not possible so the activity will not reopen when the back button is clicked and will not generate a new UV index.